### PR TITLE
fix: Github action does not work due do failing apt-get update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.19.1-slim as base
+FROM node:16.19.1-bullseye-slim as base
 
 LABEL "com.github.actions.name"="Vuepress deploy"
 LABEL "com.github.actions.description"="A GitHub Action to build and deploy Vuepress sites to GitHub Pages"


### PR DESCRIPTION
Before this fix, when the debian starts, and make first apt update, it fails because deb.debian.org have not more version debien-10 Buster. This version is now on archive.debian.org This commit update the node version is order to use the same node version but with Debian 11 Bullseye

Resolves jenkey2011/vuepress-deploy#39

**Description**
> Provide a description of what your changes do.

**Testing Instructions**
> Give us step by step instructions on how to test your changes.

**Additional Notes**
> Anything else that will help us test the pull request.